### PR TITLE
Protocol handler

### DIFF
--- a/redirect/index.html
+++ b/redirect/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+	<meta charset="utf-8">
+	<title>Redirect</title>
+	<style>
+		input[type="button"] {
+			cursor: pointer;
+			padding: 10px;
+		}
+	</style>
+</head>
+<body>
+<h1>aaaaa</h1>
+
+<h2>登録</h2>
+<input type="button" value="登録" id="register">
+<input type="button" value="解除" id="unregister">
+<script>
+	document.getElementById('register').addEventListener('click', () => {
+		navigator.registerProtocolHandler('web+redirect', './redirect.html?to=%s', '');
+		localStorage['ProtocolHandler-registered-web+redirect'] = true;
+	});
+	document.getElementById('unregister').addEventListener('click', () => {
+		navigator.unregisterProtocolHandler('web+redirect', './redirect.html?to=%s');
+		localStorage['ProtocolHandler-registered-web+redirect'] = false;
+	});
+</script>
+
+
+
+<h2>テスト</h2>
+<ul>
+	<li>
+		<a href="web+redirect:https://example.com/abc/123?x=42&y=9#foo">web+redirect:https://example.com/abc/123?x=42&y=9#foo</a>
+	</li>
+	<li>
+		<input type="button" value="open: web+redirect:https://example.com/abc/123?x=42&y=9#foo" id="open">
+		<script>
+			document.getElementById('open').addEventListener('click', () => {
+				window.open('web+redirect:https://example.com/abc/123?x=42&y=9#foo');
+			});
+		</script>
+	</li>
+</ul>
+
+<h2>参考</h2>
+<ul>
+	<li><a href="https://developer.mozilla.org/ja/docs/Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers">ウェブベースのプロトコルハンドラー - Web API | MDN</a></li>
+	<li><a href="https://developer.mozilla.org/ja/docs/Web/API/Navigator/registerProtocolHandler">Navigator.registerProtocolHandler() - Web API | MDN</a></li>
+</ul>
+</body>

--- a/redirect/redirect.html
+++ b/redirect/redirect.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+	<meta charset="utf-8">
+	<title>Redirect</title>
+</head>
+<body>
+<h1>リダイレクト</h1>
+<pre></pre>
+<script>
+	const to = new URL(document.URL).searchParams.get('to');
+	const url = to.slice('web+redirect:'.length);
+	document.querySelector('pre').innerText = `${to}\n${url}`;
+</script>
+</body>

--- a/share-page/index.html
+++ b/share-page/index.html
@@ -39,4 +39,7 @@
 	<li>(事前準備) このPWAをインストール (Android & Chrome で動作確認済み)</li>
 	<li>共有からこのアプリ (<code>Share Page</code> <img class="icon" src="./icons/144.png">) を選択</li>
 </ol>
+
+<h2>開発中</h2>
+<a href="../redirect/">プロトコルハンドラー</a>
 </body>

--- a/share-page/share_target.html
+++ b/share-page/share_target.html
@@ -54,6 +54,17 @@
 		dl.append(dt, dd);
 	});
 
+	{
+		const originalOpen = window.open;
+		window.open = _url => {
+			if (localStorage['ProtocolHandler-registered-web+redirect'] === 'true') {
+				originalOpen(`web+redirect:${_url}`);
+			} else {
+				originalOpen(_url);
+			}
+		};
+	}
+
 	const parsedUrl = (() => {
 		try {
 			return new URL(url || text);


### PR DESCRIPTION
## 目標
PWAから別ページへ遷移する際にアプリ内ブラウザではなく新規タブとして開きたい

## 手段
プロトコルハンドラーを経由してみる

https://twitter.com/tksugimoto/status/1574880604390559747

## 結果
2022/10/08 現在
Android Chromeはまだプロトコルハンドラーに未対応

[Navigator.registerProtocolHandler() - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/Navigator/registerProtocolHandler#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E3%81%AE%E4%BA%92%E6%8F%9B%E6%80%A7)
